### PR TITLE
Update generating_synthetic_data.md

### DIFF
--- a/docs/src/generating_synthetic_data.md
+++ b/docs/src/generating_synthetic_data.md
@@ -1,9 +1,9 @@
-# Generating Synthetic Data
+# Generating Example Data
 
 MLJ has a set of functions - `make_blobs`, `make_circles`,
 `make_moons` and `make_regression` (closely resembling functions in
 [scikit-learn](https://scikit-learn.org/stable/datasets/index.html#generated-datasets)
-of the same name) - for generating synthetic data sets. These are
+of the same name) - for generating example data sets. These are
 useful for testing machine learning models (e.g., testing user-defined
 composite models; see [Composing Models](@ref))
 


### PR DESCRIPTION
The term "synthetic data" is ambiguous here, because in statistics, it usually refers to "fake data" created by fitting a generative model to a dataset, then drawing random data with the correct statistical properties from it. (Usually to preserve the privacy of participants while still providing a dataset for replication.)